### PR TITLE
# Extend AlimTalk Service

### DIFF
--- a/config/laravel-sens.php
+++ b/config/laravel-sens.php
@@ -4,7 +4,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | NCLOUD SENS Service ID
+    | NCLOUD SENS Service ID for SMS or LMS
     |--------------------------------------------------------------------------
     |
     | Service ID used to authenticate the SENS api request.
@@ -12,6 +12,16 @@ return [
     */
     'service_id' => env('SENS_SERVICE_ID', ''),
 
+    /*
+    |--------------------------------------------------------------------------
+    | NCLOUD SENS Service ID for AlimTalk
+    |--------------------------------------------------------------------------
+    |
+    | Service ID used to authenticate the SENS AlimTalk api request.
+    | SMS service ID is not same with this AlimTalk service ID.
+    */
+    'alimtalk_service_id' => env('SENS_ALIMTALK_SERVICE_ID', ''),
+    'plus_friend_id' => env('SENS_PlUS_FRIEND_ID', '@id'),
     /*
     |--------------------------------------------------------------------------
     | NCLOUD SENS Access Key

--- a/src/AlimTalk/AlimTalk.php
+++ b/src/AlimTalk/AlimTalk.php
@@ -1,0 +1,56 @@
+<?php
+
+
+namespace Seungmun\Sens\AlimTalk;
+
+
+use Exception;
+use Seungmun\Sens\Exceptions\SensException;
+use Seungmun\Sens\Sens;
+
+class AlimTalk extends Sens
+{
+    public function __construct(array $config)
+    {
+        $this->httpClient();
+
+        $this->setServiceId($config['alimtalk_service_id'])
+            ->setAccessKey($config['access_key'])
+            ->setSecretKey($config['secret_key']);
+
+        $this->config = $config;
+
+    }
+
+    /**
+     * @param array $params
+     * @throws SensException
+     */
+    public function send(array $params)
+    {
+
+        if ( ! $this->assertValidTokens()) {
+            throw SensException::InvalidNCPTokens("NCP tokens are invalid.");
+        }
+
+        $uri = '{method} https://sens.apigw.ntruss.com/alimtalk/v2/services/{service}/messages';
+
+        $endpoint = $this->resolveEndpoint($uri, [
+            'method' => 'POST',
+            'service' => $this->getServiceId(),
+        ]);
+
+        try {
+            $json_encode = json_encode($params);
+            $this->httpClient()->post($endpoint['url'], [
+                'headers' => $this->prepareRequestHeaders(
+                    $endpoint['method'],
+                    $endpoint['path']
+                ),
+                'body' => $json_encode,
+            ]);
+        } catch ( Exception $e) {
+            throw new SensException($e);
+        }
+    }
+}

--- a/src/AlimTalk/AlimTalkChannel.php
+++ b/src/AlimTalk/AlimTalkChannel.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Seungmun\Sens\AlimTalk;
+
+use Illuminate\Notifications\Notification;
+use Seungmun\Sens\Exceptions\SensException;
+use Seungmun\Sens\Sms\SmsMessage;
+
+class AlimTalkChannel
+{
+    /**
+     * SENS instance implements.
+     *
+     * @var AlimTalk
+     */
+    protected $alimtalk;
+
+    /**
+     * Create a new SENS sms channel instance.
+     *
+     * @param AlimTalk $sens
+     */
+    public function __construct(AlimTalk $sens)
+    {
+        $this->alimtalk = $sens;
+    }
+
+    /**
+     * Send the specified SENS notification.
+     *
+     * @param  mixed  $notifiable
+     * @param Notification $notification
+     * @return void
+     * @throws SensException
+     */
+    public function send($notifiable, Notification $notification)
+    {
+        /** @var SmsMessage $message */
+        $message = $notification->{'toAlimTalk'}($notifiable);
+
+        $this->alimtalk->send($message->toArray());
+    }
+}

--- a/src/AlimTalk/AlimTalkMessage.php
+++ b/src/AlimTalk/AlimTalkMessage.php
@@ -1,0 +1,125 @@
+<?php
+
+
+namespace Seungmun\Sens\AlimTalk;
+
+
+class AlimTalkMessage
+{
+    /** @var string */
+    public $countryCode = '82';
+    /** @var string */
+    public $to = '';
+    /** @var string */
+    public $content = '';
+    /** @var array */
+    public $buttons = [];
+    /** @var string */
+    protected $reserveTime;
+    /** @var string */
+    protected $reserveTimeZone;
+    /** @var string */
+    protected $scheduleCode;
+    /**
+     * @var string
+     */
+    protected $templateCode;
+    /**
+     * @var string
+     */
+    protected $plusFriendId;
+    public function __construct($friendId=null)
+    {
+        if($friendId){
+            $this->plusFriendId = $friendId;
+        }else{
+            $this->plusFriendId = config('laravel-sens.plus_friend_id');
+        }
+    }
+    public function countryCode(string $countryCode)
+    {
+        $this->countryCode = $countryCode;
+
+        return $this;
+    }
+
+    public function to(string $to)
+    {
+        $this->to = $to;
+
+        return $this;
+    }
+
+    public function content(string $content)
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    public function addButton(array $btn)
+    {
+        $this->buttons[] = $btn;
+        return $this;
+    }
+
+    /**
+     * @param string $reserveTime
+     * @param string $reserveTimeZone
+     * @return AlimTalkMessage
+     */
+    public function setReserved($reserveTime, $reserveTimeZone='Asia/Seoul')
+    {
+        $this->reserveTime = $reserveTime;
+        $this->reserveTimeZone = $reserveTimeZone;
+
+        return $this;
+    }
+
+    public function setSchedule( string $code )
+    {
+        if($this->scheduleCode){
+            $this->scheduleCode = $code;
+        }
+        return $this;
+    }
+
+    public function plusFriendId(string $id)
+    {
+        $this->plusFriendId = $id;
+        return $this;
+    }
+
+    public function templateCode(string $code){
+        $this->templateCode = $code;
+        return $this;
+    }
+
+    public function toArray()
+    {
+        $buffer = [
+            "plusFriendId" => $this->plusFriendId,
+            "templateCode" => $this->templateCode,
+            "scheduleCode" => $this->scheduleCode
+        ];
+
+        if($this->reserveTime){
+            $buffer['reserveTime'] = $this->reserveTime;
+        }
+        if($this->reserveTimeZone){
+            $buffer['reserveTimeZone'] = $this->reserveTimeZone;
+        }
+        $message = [
+            'countryCode' => $this->countryCode,
+            'to' => $this->to,
+            'content' => $this->content,
+        ];
+
+        if( count( $this->buttons ) ){
+            $message['buttons'] = $this->buttons;
+        }
+        $buffer['messages'][] = $message;
+
+        return $buffer;
+    }
+}

--- a/src/AlimTalk/AlimTalkRequest.php
+++ b/src/AlimTalk/AlimTalkRequest.php
@@ -1,0 +1,86 @@
+<?php
+
+
+namespace Seungmun\Sens\AlimTalk;
+
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+
+class AlimTalkRequest
+{
+    /** @var string */
+    public $plusFriendId = '';    // Mandatory	String	카카오톡 채널명 ((구)플러스친구 아이디) @ 으로 시작됨
+    /** @var string */
+    public $templateCode = '';    // Mandatory	String	템플릿 코드
+    /** @var array|AlimTalkMessage[] */
+    public $messages = [];
+    /** @var string */
+    public $reserveTime = ''; //	Optional	String	예약 일시	메시지 발송 예약 일시 (yyyy-MM-dd HH:mm)
+    /** @var string */
+    public $reserveTimeZone = ''; //	Optional	String	예약 일시 타임존	예약 일시 타임존 (기본: Asia/Seoul)
+    /** @var string */
+    public $scheduleCode = '';    //Optional	String	스케줄 코드	등록하려는 스케줄 코드
+
+    public function __construct(array $params){
+
+        $this->mappingParams($params);
+
+    }
+
+    protected function mappingParams(array $params)
+    {
+        $attributes = ['plusFriendId','templateCode','messages','reserveTime','reserveTimeZone','scheduleCode'];
+        foreach ($attributes as $attribute){
+            $val = Arr::get($params, $attribute);
+            if($val){
+                $this->{$attribute} = $val;
+            }
+        }
+    }
+
+    public function validator()
+    {
+        return Validator::make($this->toArray(), [
+            'plusFriendId' => 'required',
+            'templateCode' => 'required',
+            'messages' => 'required|array',
+            'reserveTime' => 'nullable',
+            'reserveTimeZone' => 'nullable',
+            'scheduleCode' => 'nullable',
+        ]);
+    }
+
+    public function addMessage(AlimTalkMessage $message)
+    {
+        $this->messages[] = $message;
+
+        return $this;
+    }
+
+    public function toArray()
+    {
+        $buffer = [
+            "plusFriendId" => $this->plusFriendId,
+            "templateCode" => $this->templateCode,
+            "messages" => array_map(
+                function (AlimTalkMessage $message) {
+                    return $message->toArray();
+                },
+                $this->messages
+            )
+        ];
+
+        if($this->reserveTime){
+            $buffer['reserveTime'] = $this->reserveTime;
+        }
+        if($this->reserveTimeZone){
+            $buffer['reserveTimeZone'] = $this->reserveTimeZone;
+        }
+        if($this->scheduleCode){
+            $buffer['scheduleCode'] = $this->scheduleCode;
+        }
+
+        return $buffer;
+    }
+}

--- a/src/Sens.php
+++ b/src/Sens.php
@@ -20,7 +20,7 @@ abstract class Sens implements SensContract
     private $secretKey;
 
     /** @var array */
-    private $config = [];
+    protected $config = [];
 
     /** @var array */
     private $headers = [];

--- a/src/SensServiceProvider.php
+++ b/src/SensServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Seungmun\Sens;
 
+use Seungmun\Sens\AlimTalk\AlimTalk;
+use Seungmun\Sens\AlimTalk\AlimTalkChannel;
 use Seungmun\Sens\Sms\Sms;
 use Seungmun\Sens\Sms\SmsChannel;
 use Illuminate\Support\ServiceProvider;
@@ -25,6 +27,13 @@ class SensServiceProvider extends ServiceProvider
             ->needs(Sms::class)
             ->give(function ($app) {
                 return new Sms($app['config']->get('laravel-sens'));
+            });
+
+        // Register SENS AlimTalk service.
+        $this->app->when(AlimTalkChannel::class)
+            ->needs(AlimTalk::class)
+            ->give(function ($app) {
+                return new AlimTalk($app['config']->get('laravel-sens'));
             });
     }
 


### PR DESCRIPTION
카카오 비즈 알림톡은 별도의 서비스 아이디가 있어야 발송이 가능했습니다.
그러한점을 반영했으며, 원제작자의 디자인을 최대한 모방했습니다.
저의 NCP 계정으로 PHPUnit 을 이용해 실제 발송 테스트까지 해 보았는데, 성공했습니다.
실제로 라라벨에서 Notification 생성해서 테스트 하진 않았습니다.
살펴봐 주세요.^^