### PR TITLE
Fix only decimal phone number

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,37 @@ SENS_ALIMTALK_SERVICE_ID=your-alimtalk-service-id
 SENS_PlUS_FRIEND_ID=your-plus-friend-id
 ```
 
+If you want to put the `sms_from` value in your .env,
+
+config/services.php
+
+```php
+/*
+|--------------------------------------------------------------------------
+| SMS "From" Number
+|--------------------------------------------------------------------------
+|
+| This configuration option defines the phone number that will be used as
+| the "from" number for all outgoing text messages. You should provide
+| the number you have already reserved within your Naver Cloud Platform
+| /sens/sms-calling-number of dashboard.
+|
+*/
+'sens' => [
+    'services' => [
+        'sms' => [
+            'sender' => env('SENS_SMS_FROM'),
+        ],
+    ],
+],
+```
+
+.env:
+
+```env
+SENS_SMS_FROM=1234567890
+```
+
 ## Usage
 
 This package can be used using with the Laravel default notification feature.

--- a/src/Sms/SmsMessage.php
+++ b/src/Sms/SmsMessage.php
@@ -88,7 +88,7 @@ class SmsMessage implements SensMessage
      */
     public function from(string $from)
     {
-        $this->from = str_replace('-', '', $from);
+        $this->from = preg_replace('/[^0-9]/', '', $from);
 
         return $this;
     }
@@ -128,7 +128,7 @@ class SmsMessage implements SensMessage
     public function to(string $to)
     {
         array_push($this->messages, [
-            'to' => str_replace('-', '', $to),
+            'to' => preg_replace('/[^0-9]/', '', $to),
         ]);
 
         return $this;


### PR DESCRIPTION
According to the [NHN Cloud Platform API Guide](https://api.ncloud-docs.com/docs/en/ai-application-service-sens-smsv2), messages.to and messages.from follow the specifications below.

> Only numbers except (-) can be entered

However, phone numbers don't just contain numbers and (-).

International phone number standards (such as RFC3966 or E164) include spaces, parentheses, and +.

Therefore, according to the content of the API Guide, all characters other than numbers must be deleted without deleting only (-).